### PR TITLE
Make observe-req format configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ and (optionally) call `cancel()` on the same `endpoint` and `path` and .
 -   `endpoint` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** client endpoint name
 -   `path` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `options`  
+    -   `options.format` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** media type. (optional, default `'text'`)
+    -   `options.schema` **[Schema](#schema)** defining resources.
 -   `callback` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** 
 
 **Examples**

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -709,7 +709,7 @@ Server.prototype.observe = function(endpoint, path, options, callback) {
     throw new TypeError('Illegal schema');
   }
 
-  var mediaType = utils.getMediaType(path, null, options.format);
+  var mediaType = utils.getMediaType(path, null, options && options.format);
 
   var processStream = function(stream) {
     var contentType = stream.headers['Content-Type'];

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -230,7 +230,7 @@ Server.prototype.read = function(endpoint, path, options, callback) {
     method: 'GET', 
     pathname: path,
     options: {
-      'Content-Format': mediaType,
+      'Accept': mediaType,
     },
   })
     .then(processResponse); 
@@ -686,6 +686,9 @@ Server.prototype.delete = function(endpoint, path, callback) {
  *
  * @param  {String} endpoint - client endpoint name
  * @param  {String} path
+ * @param  {Object} [options]
+ * @param  {Schema} options.format='text'] - media type.
+ * @param  {Schema} options.schema - defining resources.
  * @param  {Function} [callback]
  * @return {Promise}
  */
@@ -705,6 +708,8 @@ Server.prototype.observe = function(endpoint, path, options, callback) {
   if (schema && !(schema instanceof Schema)) {
     throw new TypeError('Illegal schema');
   }
+
+  var mediaType = utils.getMediaType(path, null, options.format);
 
   var processStream = function(stream) {
     var contentType = stream.headers['Content-Type'];
@@ -729,7 +734,7 @@ Server.prototype.observe = function(endpoint, path, options, callback) {
     pathname: path,
     observe: true,
     options: {
-      'Accept': content.text,
+      'Accept': mediaType,
     },
   })
     .then(processStream); 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lwm2m",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lwm2m",
   "description": "Library for developing servers and client of OMA Lightweight M2M",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "homepage": "https://github.com/moleike/node-lwm2m",
   "main": "lib",
   "author": {


### PR DESCRIPTION
**Make observe-req configurable**

- generate `mediaType` from options
- keep `content.text` as default
- add `mediaType` to header of observe-req (`Accept`)

**Minor Bugfix**

- change header-property of read-req. from `Content-Format` to `Accept` to provide correct functionality with every client.